### PR TITLE
chore: alt eol chars causing cross platorm prettier visuals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,6 +83,6 @@
       {"checksConditionals": true,"checksVoidReturn": false}
     ],
 
-    "prettier/prettier": "error"
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   }
 }


### PR DESCRIPTION
Webstorm IDE on Windows was flagging issues due to the EoL characters (being Linux) via prettier, the fix is to have prettier ignore the EoL chars.